### PR TITLE
Dataset parser fixes

### DIFF
--- a/operations/gobierto-budgets/budgets_forecast/update.rb
+++ b/operations/gobierto-budgets/budgets_forecast/update.rb
@@ -35,33 +35,20 @@ tries = 0
 puts "[START] gobierto_budgets_comparator/gencat/update.rb updated_since: #{UPDATED_SINCE} storage_dir: #{STORAGE_DIR}"
 puts "[!] Running with fast run" if (ENV["FAST_RUN"] == "true")
 
-begin
-  puts "Starting try \##{tries + 1}"
+client = SocrataClient.new
 
-  client = SocrataClient.new
+client.update_budget_lines!(UPDATED_SINCE, exec_summary, DEBUG)
+exec_summary.finalize_summary
+exec_summary.print
 
-  client.update_budget_lines!(UPDATED_SINCE, exec_summary, DEBUG)
-rescue StandardError
-  puts $!
-  tries += 1
-  if tries < MAX_TRIES
-    sleep 60
-    retry
-  end
-  puts "\nExiting after #{tries} re-tries.....\n"
-ensure
-  exec_summary.finalize_summary
-  exec_summary.print
-
-  File.open("#{STORAGE_DIR}/imported_organizations_ids.update.txt", "w+") do |file|
-    file.write exec_summary.imported_organizations_ids.join("\n")
-  end
-
-  File.open("#{STORAGE_DIR}/scanned_organizations_ids.update.txt", "w+") do |file|
-    file.write exec_summary.scanned_organizations_ids.join("\n")
-  end
-
-  puts "[END] gobierto_budgets_comparator/gencat/update.rb"
-
-  exit exec_summary.success?
+File.open("#{STORAGE_DIR}/imported_organizations_ids.update.txt", "w+") do |file|
+  file.write exec_summary.imported_organizations_ids.join("\n")
 end
+
+File.open("#{STORAGE_DIR}/scanned_organizations_ids.update.txt", "w+") do |file|
+  file.write exec_summary.scanned_organizations_ids.join("\n")
+end
+
+puts "[END] gobierto_budgets_comparator/gencat/update.rb"
+
+exit exec_summary.success?

--- a/operations/gobierto-budgets/utils/record_parser.rb
+++ b/operations/gobierto-budgets/utils/record_parser.rb
@@ -17,7 +17,11 @@ class RecordParser
   end
 
   def self.parse_year(response_item)
-    Date.parse(response_item.any_exercici).year
+    if response_item.any_exercici =~ /\d{4}/
+      response_item.any_exercici.to_i
+    else
+      Date.parse(response_item.any_exercici).year
+    end
   end
 
   def self.parse_external_entity_code(response_item)


### PR DESCRIPTION
This PR 

- fixes how dates are parsed, because there's a new format of dates that includes just the year instead of the whole date
- reverts the whole exception rescue block from the client, because we weren't being notified of the errores happenning when the import failed. The client to Socrat is mucho more stable and it's been running for 8 hours without any failure so far